### PR TITLE
support millisecond precision for expiry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/lib/redis-store.js
+++ b/lib/redis-store.js
@@ -8,6 +8,8 @@ var RedisStore = function(options) {
     prefix: "rl:"
   });
 
+  var expiryMs = Math.round(1000 * options.expiry);
+
   // create the client if one isn't provided
   options.client = options.client || redis.createClient();
 
@@ -16,7 +18,7 @@ var RedisStore = function(options) {
 
     options.client.multi()
       .incr(rdskey)
-      .ttl(rdskey)
+      .pttl(rdskey)
       .exec(function(err, replies) {
         if (err) {
           return cb(err);
@@ -36,7 +38,7 @@ var RedisStore = function(options) {
         // if this is new or has no expiry
         if (replies[0] === 1 || replies[1] === -1) {
           // then expire it after the timeout
-          options.client.expire(rdskey, options.expiry);
+          options.client.pexpire(rdskey, expiryMs);
         }
 
         cb(null, replies[0]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rate-limit-redis",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Provides a Redis store for the express-rate-limit RateLimit middleware.",
   "main": "lib/redis-store.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -23,10 +23,10 @@ describe("rate-limit-redis node module", function() {
         return this;
       };
 
-      this.ttl = function(key) {
+      this.pttl = function(key) {
         opts.push(function() {
           if (keys[key] && keys[key].ttl) {
-            return Math.max(keys[key].ttl - Math.round((new Date()).valueOf() / 1000), -1);
+            return Math.max(keys[key].ttl - new Date().valueOf(), -1);
           }
 
           return -1;
@@ -44,17 +44,17 @@ describe("rate-limit-redis node module", function() {
       return this;
     };
 
-    this.expire = function(key, expiry) {
+    this.pexpire = function(key, expiry) {
       if (keys[key]) {
         if (keys[key].timeout) {
           clearTimeout(keys[key].timeout);
         }
 
-        keys[key].ttl = Math.round((new Date()).valueOf() / 1000) + expiry;
+        keys[key].pttl = new Date() + expiry;
 
         keys[key].timeout = setTimeout(function() {
           delete keys[key];
-        }, keys[key].ttl * 1000 - new Date().getTime());
+        }, keys[key].pttl - new Date().getTime());
       }
     };
 


### PR DESCRIPTION
While testing, it is often useful to use sub-seconds expiry, to make tests run faster.

This expiry parameter is still expressed in seconds to preserve compatibility with the store interface, however input can be fractional seconds.
