### PR TITLE
Added option "resetExpiryOnChange"

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ app.use(limiter);
 ## Configuration
 
 * **expiry**: seconds - how long each rate limiting window exists for. Defaults to `60`.
+* **resetExpiryOnChange**: boolean - if the expiry time should be reset every time a key is incremented/decremented. This means that when the limit is reached and the user is given a 429 response, the expiry time serves as a cooldown. Defaults to `false`.
 * **prefix**: string - prefix to add to entries in Redis. Defaults to `rl:`.
 * **client**: [Redis Client](https://github.com/NodeRedis/node_redis) or [ioredis Client](https://github.com/luin/ioredis)- A Redis Client to use. Defaults to `require('redis').createClient();`.
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ app.use(limiter);
 ## Configuration
 
 * **expiry**: seconds - how long each rate limiting window exists for. Defaults to `60`.
-* **resetExpiryOnChange**: boolean - if the expiry time should be reset every time a key is incremented/decremented. This means that when the limit is reached and the user is given a 429 response, the expiry time serves as a cooldown. Defaults to `false`.
+* **resetExpiryOnChange**: boolean - if the expiry time should be reset every time a key is incremented/decremented. This means that when the limit is reached and the user is given a 429 response, the rate limit window is extended. Defaults to `false`.
 * **prefix**: string - prefix to add to entries in Redis. Defaults to `rl:`.
 * **client**: [Redis Client](https://github.com/NodeRedis/node_redis) or [ioredis Client](https://github.com/luin/ioredis)- A Redis Client to use. Defaults to `require('redis').createClient();`.
 

--- a/lib/redis-store.js
+++ b/lib/redis-store.js
@@ -5,7 +5,8 @@ var redis = require('redis');
 var RedisStore = function(options) {
   options = defaults(options, {
     expiry: 60, // default expiry is one minute
-    prefix: "rl:"
+    prefix: "rl:",
+    resetExpiryOnChange: false
   });
 
   var expiryMs = Math.round(1000 * options.expiry);
@@ -15,7 +16,7 @@ var RedisStore = function(options) {
 
   var setExpire = function(replies, rdskey) {
     // if this is new or has no expiry
-    if (replies[0] === 1 || replies[1] === -1) {
+    if (options.resetExpiryOnChange || replies[0] === 1 || replies[1] === -1) {
       // then expire it after the timeout
       options.client.pexpire(rdskey, expiryMs);
     }


### PR DESCRIPTION
Sets the expiry time back to `options.expiry` when incrementing/decrementing. This aligns better with how the default handler in express-rate-limit displays the time in the Retry-After header.

This basically means that when a users reaches the limit and receives a 429 response, the expiry time will serve as a cooldown, so this is probably not ideal for long expiry times. Obviously this is just a preference, so if you disagree then feel free to close the PR. I don't see how it would hurt to have the option. :)

The option defaults to `false` to prevent a breaking change.