### PR TITLE
Add support for redis url

### DIFF
--- a/lib/redis-store.js
+++ b/lib/redis-store.js
@@ -6,13 +6,14 @@ var RedisStore = function(options) {
   options = defaults(options, {
     expiry: 60, // default expiry is one minute
     prefix: "rl:",
-    resetExpiryOnChange: false
+    resetExpiryOnChange: false,
+    redisUrl: undefined,
   });
 
   var expiryMs = Math.round(1000 * options.expiry);
 
   // create the client if one isn't provided
-  options.client = options.client || redis.createClient();
+  options.client = options.client || redis.createClient(options.redisUrl);
 
   var setExpire = function(replies, rdskey) {
     // if this is new or has no expiry


### PR DESCRIPTION
Add `redisUrl` in options, so instead of passing a client I can just pass the redis url