### PR TITLE
docs(readme): fix typo in ioredis example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -116,7 +116,7 @@ const limiter = rateLimit({
   // Redis store configuration
   store: new RedisStore({
     // @ts-expect-error - Known issue: the `call` function is not present in @types/ioredis
-    sendCommand: (...args: string[]) => client.call(args),
+    sendCommand: (...args: string[]) => client.call(...args),
   }),
 });
 app.use(limiter);


### PR DESCRIPTION
## What Does This PR Do?

ioredis client's `call` method should be provided `...args` instead of `args`

I think this was a typo as the correct command is written [here](https://github.com/wyattjoh/rate-limit-redis/blob/75d16f81ac0dbda139a5aa0ab75e46ce9d74db4c/readme.md?plain=1#L142).

## Checklist

- [x] What this PR adds/changes/removes has been explained.
- [x] All tests (`npm run test`) pass.
- [x] The linter and formatter (`npm run lint`) do not report any errors.
