### PR TITLE
chore(issue-templates): add redis client field to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -47,3 +47,9 @@ body:
         - CommonJS
     validations:
       required: true
+  - type: input
+    attributes:
+      label: Redis Client
+      description: Which Redis client do you use to connect with the Redis server?
+    validations:
+      required: true


### PR DESCRIPTION
## Related Issues

Asks users which Redis Client they use in the bug report template itself, so we don't need to ask again [like this](https://github.com/wyattjoh/rate-limit-redis/issues/71#issuecomment-1080208014).

## What Does This PR Do?

### Added

- Added a new field to the bug report template that prompts users to fill in the Redis Client they use.

## Caveats/Problems/Issues

--

## Checklist

- [x] The issues that this PR fixes/closes have been mentioned above.
- [x] What this PR adds/changes/removes has been explained.
- [x] All tests (`npm run test`) pass.
- [x] The linter and formatter (`npm run lint`) do not report any errors.
- [x] All added/modified code has been commented, and
      methods/classes/constants/types have been annotated with TSDoc comments.
- [x] If a new feature has been added or a bug has been fixed, tests have been
      added for the same.
