### PR TITLE
Add types definition to exports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "rate-limit-redis",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "devDependencies": {
         "@jest/globals": "^27.4.6",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
-      "require": "./dist/index.cjs"
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.d.ts"
     }
   },
   "main": "./dist/index.cjs",


### PR DESCRIPTION
In order to make the `types` be exported, add `types` to `exports` in `package.json`.